### PR TITLE
VRH 2021 + kleine updates

### DIFF
--- a/src/simulator/mod.rs
+++ b/src/simulator/mod.rs
@@ -121,6 +121,7 @@ impl Simulator {
         let fees_pct = vars.yearly_fees / 12.00 / 100.00;
         let tax_fn = match vars.tax_strategy.as_str() {
             "vermogensbelasting 2020" => taxes::vermogensbelasting_2020,
+            "vermogensbelasting 2021" => taxes::vermogensbelasting_2021,
             "vermogensbelasting 2022" => taxes::vermogensbelasting_2022,
             _=> taxes::tax_free,
         };

--- a/src/simulator/taxes.rs
+++ b/src/simulator/taxes.rs
@@ -7,8 +7,16 @@ pub fn vermogensbelasting_2020(capital: f32, _gains: f32, _with_partner: bool, _
     let schijf_1 = (capital.min(72_798.00) * 0.01789).floor();
     let schijf_2 = ((0.00 as f32).max(capital.min(1_005_573.00) - 72_798.00) * 0.04185).floor();
     let schijf_3 = ((0.00 as f32).max(capital - 1_005_573.00) * 0.0528).floor();
-    let heffingskorting = if _with_heffingskorting { 2_711.00 } else { 0.00 };
-    let schijven = schijf_1 + schijf_2 + schijf_3;
+	let schijven = schijf_1 + schijf_2 + schijf_3;
+	let heffingskorting = 0.00;
+	if _with_heffingskorting && schijven < 68_507 {
+		if schijven < 20_711.00 {
+			heffingskorting = 2_711.00;
+		}
+		else {
+			heffingskorting = 2_711.00 - (schijven - 20_711.00) * 0.05672;
+		}
+	}
     let tax = (0.00 as f32).max((schijven * 0.30).floor() - heffingskorting);
     return if _with_partner { tax * 2.0 } else { tax };
 }
@@ -22,8 +30,16 @@ pub fn vermogensbelasting_2021(capital: f32, _gains: f32, _with_partner: bool, _
     let schijf_1 = (capital.min(100_000.00) * 0.019).floor();
     let schijf_2 = ((0.00 as f32).max(capital.min(1_000_000.00) - 100_000.00) * 0.045).floor();
 	let schijf_3 = ((0.00 as f32).max(capital - 1_000_000.00) * 0.0569).floor();
-	let heffingskorting = if _with_heffingskorting { 2_837.00 } else { 0.00 };
 	let schijven = schijf_1 + schijf_2 + schijf_3;
+	let heffingskorting = 0.00;
+	if _with_heffingskorting && schijven < 68_507 {
+		if schijven < 21_043.00 {
+			heffingskorting = 2_837.00;
+		}
+		else {
+			heffingskorting = 2_837.00 - (schijven - 21_043.00) * 0.05977;
+		}
+	}
     let tax = (0.00 as f32).max((schijven * 0.31).floor() - heffingskorting);
     return if _with_partner { tax * 2.0 } else { tax };
 }

--- a/src/simulator/taxes.rs
+++ b/src/simulator/taxes.rs
@@ -27,9 +27,9 @@ pub fn vermogensbelasting_2021(capital: f32, _gains: f32, _with_partner: bool, _
       return 0.00;
     }
 
-    let schijf_1 = (capital.min(100_000.00) * 0.019).floor();
-    let schijf_2 = ((0.00 as f32).max(capital.min(1_000_000.00) - 100_000.00) * 0.045).floor();
-	let schijf_3 = ((0.00 as f32).max(capital - 1_000_000.00) * 0.0569).floor();
+    let schijf_1 = (capital.min(100_001.00) * 0.019).floor();
+    let schijf_2 = ((0.00 as f32).max(capital.min(1_000_001.00) - 100_001.00) * 0.045).floor();
+	let schijf_3 = ((0.00 as f32).max(capital - 1_000_001.00) * 0.0569).floor();
 	let schijven = schijf_1 + schijf_2 + schijf_3;
 	let heffingskorting = 0.00;
 	if _with_heffingskorting && schijven < 68_507 {
@@ -82,6 +82,20 @@ mod tests {
         
         // https://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/belastingdienst/prive/vermogen_en_aanmerkelijk_belang/vermogen/belasting_betalen_over_uw_vermogen/grondslag_sparen_en_beleggen/berekening-2020/voorbeeld-u-hebt-spaargeld-met-uw-fiscale-partner-en-geeft-ieder-de-helft-van-de-grondslag-op
         assert_eq!(vermogensbelasting_2020(261_692.00, 100.00, true, false), 1_464.00);
+	}
+	
+    #[test]
+    fn test_vermogensbelasting_2021() {
+        assert_eq!(vermogensbelasting_2021(0.00, 0.00, false, false), 0.00);
+        assert_eq!(vermogensbelasting_2021(50_000.00, 0.00, false, false), 0.00);
+		assert_eq!(vermogensbelasting_2021(100_000.00, 0.00, false, false), 294.00);
+        assert_eq!(vermogensbelasting_2021(250_000.00, 0.00, false, false), 2_387.00);
+        assert_eq!(vermogensbelasting_2021(1_000_000.00, 0.00, false, false), 12_849.00);
+
+		// TODO: Examples from belastingdienst website.
+        //assert_eq!(vermogensbelasting_2021(150_000.00, 100.00, false, false), 972.00);
+        //assert_eq!(vermogensbelasting_2021(1_000_000.00, 0.00, false, false), 11_644.00);
+        //assert_eq!(vermogensbelasting_2021(261_692.00, 100.00, true, false), 1_464.00);
     }
 
     #[test]

--- a/src/simulator/taxes.rs
+++ b/src/simulator/taxes.rs
@@ -13,6 +13,21 @@ pub fn vermogensbelasting_2020(capital: f32, _gains: f32, _with_partner: bool, _
     return if _with_partner { tax * 2.0 } else { tax };
 }
 
+pub fn vermogensbelasting_2021(capital: f32, _gains: f32, _with_partner: bool, _with_heffingskorting: bool) -> f32 {
+    let capital = if _with_partner { capital / 2.0 } else { capital } - 50_000.00;
+    if capital < 0.00 {
+      return 0.00;
+    }
+
+    let schijf_1 = (capital.min(100_000.00) * 0.019).floor();
+    let schijf_2 = ((0.00 as f32).max(capital.min(1_000_000.00) - 100_000.00) * 0.045).floor();
+	let schijf_3 = ((0.00 as f32).max(capital - 1_000_000.00) * 0.0569).floor();
+	let heffingskorting = if _with_heffingskorting { 2_837.00 } else { 0.00 };
+	let schijven = schijf_1 + schijf_2 + schijf_3;
+    let tax = (0.00 as f32).max((schijven * 0.31).floor() - heffingskorting);
+    return if _with_partner { tax * 2.0 } else { tax };
+}
+
 pub fn vermogensbelasting_2022(capital: f32, _gains: f32, _with_partner: bool, _with_heffingskorting: bool) -> f32 {
   let belastingvrije_voet = if _with_partner { 30_846.00 * 2.0 } else { 30_846.00 };
   if capital < belastingvrije_voet {

--- a/templates/index.html.tera
+++ b/templates/index.html.tera
@@ -33,6 +33,7 @@
         <label>Taxes</label>
         <select name="tax_strategy" required>
             <option value="vermogensbelasting 2020">vermogensbelasting 2020</option>
+            <option value="vermogensbelasting 2021">vermogensbelasting 2021</option>
             <option value="vermogensbelasting 2022">vermogensbelasting 2022 (voorstel)</option>
             <option value="tax free">tax free</option>
         </select>


### PR DESCRIPTION
Berekening voor vermogensbelasting 2021 ingevuld aan de hand van de tabel [hier](https://bieb.knab.nl/sparen-investeren/vermogensbelasting-in-2021-hoeveel-belasting-betaal-je-in-box-3), niet 100% zeker of die correct is maar dat lijkt me wel.  
  
Verder de heffingskorting berekening wat juister gemaakt, want technisch gezien is die gebaseerd op het (verzamel)inkomen, wat bij enkel box 3 inkomen je opbrengsten in box 3 zijn. Tabel [hiervandaan](https://financieel.infonu.nl/belasting/125915-algemene-heffingskorting-2021.html) getoverd.  
  
Tests even snel gemaakt a.h.v. een excel sheetje, nog niet gedraait (heb geen react omgeving draaien en geen zin om die op te zetten...)